### PR TITLE
Allow passing torch schedulers to torch_minimize and general CEEM hp scheduler

### DIFF
--- a/ceem/ceem.py
+++ b/ceem/ceem.py
@@ -120,10 +120,17 @@ class CEEM:
             learner_opt_kwargs = [learner_opt_kwargs for _ in range(len(self._learning_criteria))]
 
         if hp_schedulers is not None:
-            for i in range(len(self._learning_criteria)):
-                for hp, scheduler in hp_schedulers[i].items():
+            if isinstance(hp_schedulers, dict):
+                for hp, scheduler in hp_schedulers.items():
                     newhp = scheduler.step()
-                    learner_opt_kwargs[i][hp] = newhp
+                    for lok in learner_opt_kwargs:
+                        lok[hp] = newhp
+            else:
+                for i in range(len(self._learning_criteria)):
+                    for hp, scheduler in hp_schedulers[i].items():
+                        newhp = scheduler.step()
+                        learner_opt_kwargs[i][hp] = newhp
+        
 
         assert len(learner_criterion_kwargs) == len(self._learning_criteria)
         assert len(learner_opt_kwargs) == len(self._learning_criteria)
@@ -161,9 +168,7 @@ class CEEM:
           subset (int):
         """
         if hp_schedulers is not None:
-            if isinstance(hp_schedulers, dict):
-                hp_schedulers = [deepcopy(hp_schedulers) for _ in range(len(self._learning_criteria))]
-            else:
+            if not isinstance(hp_schedulers, dict):
                 assert len(hp_schedulers) == len(self._learning_criteria)
 
         for epoch in range(nepochs):

--- a/ceem/ceem.py
+++ b/ceem/ceem.py
@@ -3,6 +3,7 @@
 #
 from typing import Any, Callable, Tuple
 
+from copy import deepcopy
 import joblib
 import numpy as np
 import torch
@@ -119,17 +120,10 @@ class CEEM:
             learner_opt_kwargs = [learner_opt_kwargs for _ in range(len(self._learning_criteria))]
 
         if hp_schedulers is not None:
-            if isinstance(hp_schedulers, dict):
-                hp_schedulers = [hp_schedulers for _ in range(len(self._learning_criteria))]
-            else:
-                assert len(hp_schedulers) == len(self._learning_criteria)
-
-        if hp_schedulers is not None:
             for i in range(len(self._learning_criteria)):
                 for hp, scheduler in hp_schedulers[i].items():
                     newhp = scheduler.step()
                     learner_opt_kwargs[i][hp] = newhp
-        
 
         assert len(learner_criterion_kwargs) == len(self._learning_criteria)
         assert len(learner_opt_kwargs) == len(self._learning_criteria)
@@ -166,6 +160,12 @@ class CEEM:
           learner_opt_kwargs (dict):
           subset (int):
         """
+        if hp_schedulers is not None:
+            if isinstance(hp_schedulers, dict):
+                hp_schedulers = [deepcopy(hp_schedulers) for _ in range(len(self._learning_criteria))]
+            else:
+                assert len(hp_schedulers) == len(self._learning_criteria)
+
         for epoch in range(nepochs):
             xs, smooth_metrics, learn_metrics = self.step(xs, sys, smooth_solver_kwargs,
                                                           learner_criterion_kwargs,

--- a/ceem/utils.py
+++ b/ceem/utils.py
@@ -99,3 +99,27 @@ def get_grad_norm(params):
             total_norm += param_norm.item()**2
     total_norm = total_norm**(1. / 2)
     return total_norm
+
+class Scheduler:
+    def __init__(self, init_val, last_epoch=-1):
+        self.init_val = init_val
+        self.last_epoch = last_epoch
+        self._last_val = init_val
+
+    def step(self, epoch=None):
+        raise NotImplementedError()
+
+    def get_val(self):
+        return self._last_val
+
+class LambdaScheduler(Scheduler):
+    def __init__(self, init_val, val_lambda, last_epoch=-1):
+        self.val_lambda = val_lambda
+        super().__init__(init_val, last_epoch)
+
+    def step(self, epoch=None):
+        if epoch is not None:
+            self.last_epoch = epoch
+
+        self._last_val = self.init_val * self.val_lambda(self.last_epoch)
+        return self._last_val

--- a/ceem/utils.py
+++ b/ceem/utils.py
@@ -120,6 +120,7 @@ class LambdaScheduler(Scheduler):
     def step(self, epoch=None):
         if epoch is not None:
             self.last_epoch = epoch
-
+        else:
+            self.last_epoch += 1
         self._last_val = self.init_val * self.val_lambda(self.last_epoch)
         return self._last_val

--- a/tests/ceem_test.py
+++ b/tests/ceem_test.py
@@ -100,7 +100,7 @@ def test_ceem():
     ceem = CEEM(smoothing_criteria, learning_criteria, learning_params, learning_opts,
                 epoch_callbacks, termination_callback, parallel=2)
 
-    hp_scheduler = {'tr_rho' : utils.LambdaScheduler(0.01, lambda x: 0.99**x)}
+    hp_scheduler = {'tr_rho' : utils.LambdaScheduler(0.01, lambda x: x)}
     # run CEEM
 
     x0 = torch.zeros_like(xtr)

--- a/tests/ceem_test.py
+++ b/tests/ceem_test.py
@@ -100,13 +100,14 @@ def test_ceem():
     ceem = CEEM(smoothing_criteria, learning_criteria, learning_params, learning_opts,
                 epoch_callbacks, termination_callback, parallel=2)
 
+    hp_scheduler = {'tr_rho' : utils.LambdaScheduler(0.01, lambda x: 0.99**x)}
     # run CEEM
 
     x0 = torch.zeros_like(xtr)
 
     ceem.train(xs=x0, sys=sys, nepochs=150, 
         smooth_solver_kwargs = smooth_solver_kwargs,
-        learner_opt_kwargs=learner_opt_kwargs, subset=1)
+        learner_opt_kwargs=learner_opt_kwargs, subset=1, hp_schedulers=hp_scheduler)
 
     assert tcb(0)
     if tcb(0):

--- a/tests/ls_learner_test.py
+++ b/tests/ls_learner_test.py
@@ -45,7 +45,9 @@ def test_learner():
     vector_to_parameters(vparams, params)
 
     opt_result = learner(sys, [dyncrit], [x], ['torch_minimize'], [params], [{}], opt_kwargs_list=[{
-        'nan_line_search':True
+        'nan_line_search': True,
+        'scheduler': 'ExponentialLR',
+        'scheduler_kwargs': {'gamma': 0.99,}
     }])[0]
 
     params = list(sys.parameters())[:2]


### PR DESCRIPTION
Currently would not support `ReduceLROnPlateau` which has different stepping protocol.
Also only supporting schedulers available in `torch.optim.lr_scheduler`.